### PR TITLE
Prepare basic CI-Pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -41,9 +41,15 @@ machine-controller-manager-provider-kubevirt:
         image: 'golang:1.13.3'
   jobs:
     head-update:
+      steps:
+        verify:
+          image: 'golang:1.14.4'
       traits:
         draft_release: ~
     pull-request:
+      steps:
+        verify:
+          image: 'golang:1.14.4'
       traits:
         pull-request: ~
     release:

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
+apt-get update
+apt-get install -y unzip
+
+mkdir -p /go/src/github.com/gardener/machine-controller-manager-provider-kubevirt
+cp -r . /go/src/github.com/gardener/machine-controller-manager-provider-kubevirt
+cd /go/src/github.com/gardener/machine-controller-manager-provider-kubevirt
+
+make verify


### PR DESCRIPTION
Contains a simple pipeline definition (`verify` for head-updates and pull requests) and the `verify` script.

__Note__: currently assumes that there will be a makefile with a `verify-extended` target