### PR TITLE
validating secrets on machine server calls

### DIFF
--- a/pkg/kubevirt/machine_server_util.go
+++ b/pkg/kubevirt/machine_server_util.go
@@ -1,0 +1,56 @@
+package kubevirt
+
+import (
+	"encoding/json"
+	"fmt"
+
+	api "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/apis"
+	clouderrors "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/errors"
+	"github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/validation"
+
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+// decodeProviderSpecAndSecret converts request parameters to api.ProviderSpec
+func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *corev1.Secret) (*api.KubeVirtProviderSpec, error) {
+	var (
+		providerSpec *api.KubeVirtProviderSpec
+	)
+
+	// Extract providerSpec
+	err := json.Unmarshal(machineClass.ProviderSpec.Raw, &providerSpec)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	validationErrors := validation.ValidateKubevirtProviderSpecAndSecret(providerSpec, secret)
+	if validationErrors != nil {
+		err = fmt.Errorf("error while validating ProviderSpec %v", validationErrors)
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return providerSpec, nil
+}
+
+// prepareErrorf preapre, format and wrap an error on the machine server level.
+func prepareErrorf(err error, format string, args ...interface{}) error {
+	var (
+		code    codes.Code
+		wrapped error
+	)
+	switch err.(type) {
+	case *clouderrors.MachineNotFoundError:
+		code = codes.NotFound
+		wrapped = err
+	default:
+		code = codes.Internal
+		wrapped = errors.Wrap(err, fmt.Sprintf(format, args...))
+	}
+	klog.V(2).Infof(wrapped.Error())
+	return status.Error(code, wrapped.Error())
+}

--- a/pkg/kubevirt/util/util.go
+++ b/pkg/kubevirt/util/util.go
@@ -15,53 +15,11 @@
 package util
 
 import (
-	"encoding/json"
 	"fmt"
 
-	api "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/apis"
-	clouderrors "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/errors"
-
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/klog"
 )
-
-// DecodeProviderSpecAndSecret converts request parameters to api.ProviderSpec
-func DecodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass) (*api.KubeVirtProviderSpec, error) {
-	var (
-		providerSpec *api.KubeVirtProviderSpec
-	)
-
-	// Extract providerSpec
-	err := json.Unmarshal(machineClass.ProviderSpec.Raw, &providerSpec)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	return providerSpec, nil
-}
-
-// PrepareErrorf preapre, format and wrap an error on the machine server level.
-func PrepareErrorf(err error, format string, args ...interface{}) error {
-	var (
-		code    codes.Code
-		wrapped error
-	)
-	switch err.(type) {
-	case *clouderrors.MachineNotFoundError:
-		code = codes.NotFound
-		wrapped = err
-	default:
-		code = codes.Internal
-		wrapped = errors.Wrap(err, fmt.Sprintf(format, args...))
-	}
-	klog.V(2).Infof(wrapped.Error())
-	return status.Error(code, wrapped.Error())
-}
 
 // DNSPolicy receives a policy as a string and converts it to a kubevirt DNSPolicy to be used in the virtual machine.
 func DNSPolicy(policy string) (corev1.DNSPolicy, error) {

--- a/pkg/kubevirt/validation/validation.go
+++ b/pkg/kubevirt/validation/validation.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// ValidateKubevirtSecret validates kubevirt spec and secret to check if all fields are present and valid
-func ValidateKubevirtSecret(spec *api.KubeVirtProviderSpec, secrets *corev1.Secret) []error {
+// ValidateKubevirtProviderSpecAndSecret validates kubevirt spec and secret to check if all fields are present and valid
+func ValidateKubevirtProviderSpecAndSecret(spec *api.KubeVirtProviderSpec, secrets *corev1.Secret) []error {
 	var validationErrors []error
 
 	if spec.CPUs == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
A MachineClass has a secret reference which is used to get the userdata and some cloud provider related configs. If the secret was deleted the machine controller kubevirt cloud provider will panic. This PR guarantees the the secrets is not reconciled in case of being nil and return error. 

**Release note**:
```improvement operator
Validating the secrets when they are reconciled and return error when it is not found 
```
