### PR TITLE
Don't wrap errors from unexported methods in core.go

### DIFF
--- a/pkg/kubevirt/core/core.go
+++ b/pkg/kubevirt/core/core.go
@@ -217,7 +217,7 @@ func (p PluginSPIImpl) DeleteMachine(ctx context.Context, machineName, providerI
 			klog.V(2).Infof("skip virtualMachine evicting, virtualMachine instance %s is not found", machineName)
 			return "", nil
 		}
-		return "", fmt.Errorf("failed to get virtualMachine: %v", err)
+		return "", err
 	}
 
 	if err := client.IgnoreNotFound(c.Delete(ctx, virtualMachine)); err != nil {
@@ -300,7 +300,7 @@ func (p PluginSPIImpl) listVMs(ctx context.Context, secret *corev1.Secret) (map[
 func (p PluginSPIImpl) machineProviderID(ctx context.Context, secret *corev1.Secret, virtualMachineName, namespace string) (string, error) {
 	virtualMachine, err := p.getVM(ctx, secret, virtualMachineName, namespace)
 	if err != nil {
-		return "", fmt.Errorf("failed to get virtualMachine: %v", err)
+		return "", err
 	}
 
 	return encodeProviderID(string(virtualMachine.UID)), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoids wrapping errors from unexported methods in `core.go`. This is undesirable for 2 reasons:
* Since these errors come from the same package, wrapping them doesn't add much additional context.
* Wrapping the error from `getVM` changes the type of the returned error, which causes an `Internal` instead of `NotFound` error to be returned if a machine is not found, which breaks the machine creation flow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
