### PR TITLE
adding ssh key support

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -37,4 +37,7 @@ type KubeVirtProviderSpec struct {
 	// DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
 	// +optional
 	DNSPolicy string `json:"dnsPolicy,omitempty"`
+	// SSHKeys is an optional array of ssh public keys to deploy to VM (may already be included in UserData)
+	// +optional
+	SSHKeys []string `json:"sshKeys,omitempty"`
 }

--- a/pkg/kubevirt/core/util_test.go
+++ b/pkg/kubevirt/core/util_test.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	testCases = []struct {
+		name             string
+		userData         string
+		sshKeys          []string
+		expectedUserData string
+		expectedError    bool
+	}{
+		{
+			name:             "`ssh_authorized_keys` key already exists error",
+			userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu",
+			sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
+			expectedUserData: "",
+			expectedError:    true,
+		},
+		{
+			name:             "add user ssh key to userdata successfully",
+			userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test",
+			sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
+			expectedUserData: "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b",
+			expectedError:    false,
+		},
+	}
+)
+
+func TestAddUserSSHKeysToUserData(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			u, err := addUserSSHKeysToUserData(testCase.userData, testCase.sshKeys)
+			if testCase.expectedError && err == nil {
+				t.Fatal("expected an error but got error: nil")
+			}
+
+			if err != nil && !testCase.expectedError {
+				t.Fatalf("unexpected error was encoutred: %v", err)
+			}
+
+			if strings.TrimSpace(testCase.expectedUserData) != strings.TrimSpace(u) {
+				t.Fatalf("expecting userdata: %v and got: %v", testCase.expectedUserData, u)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ssh keys support to the kubevirt cloud provider.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/gardener-extension-provider-kubevirt/issues/10

**Special notes for your reviewer**:
Next step is the integrate it in the kubevirt extension.
 
**Release note**:
```improvement operator
ssh keys support for kubevirt cloud provider
```
