### PR TITLE
Use namespace from provider secret

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -26,14 +26,12 @@ type KubeVirtProviderSpec struct {
 	CPUs string `json:"cpus,omitempty"`
 	// Memory specifies how much memroy the vm will request.
 	Memory string `json:"memory,omitempty"`
-	// Namespace specifies the namespace where the vm should be created.
-	Namespace string `json:"namespace,omitempty"`
 	// DNSConfig Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	// +optional
 	DNSConfig string `json:"dnsConfig,omitempty"`
 	// DNSPolicy Set DNS policy for the pod. Defaults to "ClusterFirst" and valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-	//'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have
+	// 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have
 	// DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
 	// +optional
 	DNSPolicy string `json:"dnsPolicy,omitempty"`

--- a/pkg/kubevirt/core/core.go
+++ b/pkg/kubevirt/core/core.go
@@ -43,28 +43,41 @@ import (
 // ProviderName specifies the machine controller for kubevirt cloud provider
 const ProviderName = "kubevirt"
 
-// ClientFunc creates a client based on the kubeconfig saved in the secret data.
-type ClientFunc func(secret *corev1.Secret) (client.Client, error)
+// ClientFactory creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+type ClientFactory interface {
+	// GetClient creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+	// It also returns the namespace of the kubeconfig's current context.
+	GetClient(secret *corev1.Secret) (client.Client, string, error)
+}
+
+// ClientFactoryFunc is a function that implements ClientFactory.
+type ClientFactoryFunc func(secret *corev1.Secret) (client.Client, string, error)
+
+// GetClient creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+// It also returns the namespace of the kubeconfig's current context.
+func (f ClientFactoryFunc) GetClient(secret *corev1.Secret) (client.Client, string, error) {
+	return f(secret)
+}
 
 // PluginSPIImpl is the real implementation of PluginSPI interface
 // that makes the calls to the provider SDK
 type PluginSPIImpl struct {
-	client ClientFunc
+	cf ClientFactory
 }
 
-// NewPluginSPIImpl creates a new kubevirt cloud provider based on the passed client or secret.
-func NewPluginSPIImpl(client ClientFunc) (*PluginSPIImpl, error) {
+// NewPluginSPIImpl creates a new PluginSPIImpl with the given ClientFactory.
+func NewPluginSPIImpl(cf ClientFactory) (*PluginSPIImpl, error) {
 	return &PluginSPIImpl{
-		client: client,
+		cf: cf,
 	}, nil
 }
 
-// CreateMachine creates a kubevirt virtual machine based on the passed provider spec with an associated data volume based on the
-// DataVolumeTemplate. It also creates a secret where the userdata(cloud-init) are saved and mounted on the vm.
+// CreateMachine creates a Kubevirt virtual machine with the given name and an associated data volume based on the
+// DataVolumeTemplate, using the given provider spec. It also creates a secret where the userdata(cloud-init) are saved and mounted on the VM.
 func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, providerSpec *api.KubeVirtProviderSpec, secret *corev1.Secret) (providerID string, err error) {
-	c, err := p.client(secret)
+	c, namespace, err := p.cf.GetClient(secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kubevirt client: %v", err)
+		return "", fmt.Errorf("failed to create client: %v", err)
 	}
 
 	requestsAndLimits, err := util.ParseResources(providerSpec.CPUs, providerSpec.Memory)
@@ -74,7 +87,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 
 	pvcSize, err := resource.ParseQuantity(providerSpec.PVCSize)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse value of pvcSize field: %v", err)
+		return "", fmt.Errorf("failed to parse pvcSize field: %v", err)
 	}
 
 	var (
@@ -89,7 +102,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 	if providerSpec.DNSPolicy != "" {
 		dnsPolicy, err = util.DNSPolicy(providerSpec.DNSPolicy)
 		if err != nil {
-			return "", fmt.Errorf("invalid dns policy: %v", err)
+			return "", fmt.Errorf("invalid DNS policy: %v", err)
 		}
 	}
 
@@ -115,7 +128,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 	virtualMachine := &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName,
-			Namespace: providerSpec.Namespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				"kubevirt.io/vm": machineName,
 			},
@@ -199,7 +212,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 	}
 
 	if err := c.Create(ctx, virtualMachine); err != nil {
-		return "", fmt.Errorf("failed to create vmi: %v", err)
+		return "", fmt.Errorf("failed to create VirtualMachine: %v", err)
 	}
 
 	userDataSecret := &corev1.Secret{
@@ -215,49 +228,59 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 		return "", fmt.Errorf("failed to create secret for userdata: %v", err)
 	}
 
-	return p.machineProviderID(ctx, secret, machineName, providerSpec.Namespace)
+	return p.machineProviderID(ctx, c, machineName, namespace)
 }
 
-// DeleteMachine delete the virtual machine which then delete tha cirtual machine instance and all associated resources such DataVolume.
-func (p PluginSPIImpl) DeleteMachine(ctx context.Context, machineName, providerID string, providerSpec *api.KubeVirtProviderSpec, secrets *corev1.Secret) (foundProviderID string, err error) {
-	c, err := p.client(secrets)
+// DeleteMachine deletes the Kubevirt virtual machine with the given name.
+func (p PluginSPIImpl) DeleteMachine(ctx context.Context, machineName, _ string, _ *api.KubeVirtProviderSpec, secret *corev1.Secret) (foundProviderID string, err error) {
+	c, namespace, err := p.cf.GetClient(secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kubevirt client: %v", err)
+		return "", fmt.Errorf("failed to create client: %v", err)
 	}
 
-	virtualMachine, err := p.getVM(ctx, secrets, machineName, providerSpec.Namespace)
+	virtualMachine, err := p.getVM(ctx, c, machineName, namespace)
 	if err != nil {
 		if clouderrors.IsMachineNotFoundError(err) {
-			klog.V(2).Infof("skip virtualMachine evicting, virtualMachine instance %s is not found", machineName)
+			klog.V(2).Infof("skip VirtualMachine evicting, VirtualMachine instance %s is not found", machineName)
 			return "", nil
 		}
 		return "", err
 	}
 
 	if err := client.IgnoreNotFound(c.Delete(ctx, virtualMachine)); err != nil {
-		return "", fmt.Errorf("failed to delete virtualMachine %v: %v", machineName, err)
+		return "", fmt.Errorf("failed to delete VirtualMachine %v: %v", machineName, err)
 	}
 	return encodeProviderID(string(virtualMachine.UID)), nil
 }
 
-// GetMachineStatus fetches the virtual machine provider id based on the machine name and namespace.
-func (p PluginSPIImpl) GetMachineStatus(ctx context.Context, machineName, providerID string, providerSpec *api.KubeVirtProviderSpec, secrets *corev1.Secret) (foundProviderID string, err error) {
-	return p.machineProviderID(ctx, secrets, machineName, providerSpec.Namespace)
-}
-
-// ListMachines lists all virtual machines provider ids in a specific namespace.
-func (p PluginSPIImpl) ListMachines(ctx context.Context, providerSpec *api.KubeVirtProviderSpec, secrets *corev1.Secret) (providerIDList map[string]string, err error) {
-	return p.listVMs(ctx, secrets)
-}
-
-// ShutDownMachine sets the running field of the virtual machine to false which in turns will stop the virtual machine instance of being running.
-func (p PluginSPIImpl) ShutDownMachine(ctx context.Context, machineName, providerID string, providerSpec *api.KubeVirtProviderSpec, secrets *corev1.Secret) (foundProviderID string, err error) {
-	c, err := p.client(secrets)
+// GetMachineStatus fetches the provider id of the Kubevirt virtual machine with the given name.
+func (p PluginSPIImpl) GetMachineStatus(ctx context.Context, machineName, _ string, _ *api.KubeVirtProviderSpec, secret *corev1.Secret) (foundProviderID string, err error) {
+	c, namespace, err := p.cf.GetClient(secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kubevirt client: %v", err)
+		return "", fmt.Errorf("failed to create client: %v", err)
 	}
 
-	virtualMachine, err := p.getVM(ctx, secrets, machineName, providerSpec.Namespace)
+	return p.machineProviderID(ctx, c, machineName, namespace)
+}
+
+// ListMachines lists the provider ids of all Kubevirt virtual machines.
+func (p PluginSPIImpl) ListMachines(ctx context.Context, _ *api.KubeVirtProviderSpec, secret *corev1.Secret) (providerIDList map[string]string, err error) {
+	c, namespace, err := p.cf.GetClient(secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %v", err)
+	}
+
+	return p.listVMs(ctx, c, namespace)
+}
+
+// ShutDownMachine shuts down the Kubevirt virtual machine with the given name by setting its spec.running field to false.
+func (p PluginSPIImpl) ShutDownMachine(ctx context.Context, machineName, _ string, _ *api.KubeVirtProviderSpec, secret *corev1.Secret) (foundProviderID string, err error) {
+	c, namespace, err := p.cf.GetClient(secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to create client: %v", err)
+	}
+
+	virtualMachine, err := p.getVM(ctx, c, machineName, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -266,18 +289,13 @@ func (p PluginSPIImpl) ShutDownMachine(ctx context.Context, machineName, provide
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		return c.Update(ctx, virtualMachine)
 	}); err != nil {
-		return "", fmt.Errorf("failed to update machine running state: %v", err)
+		return "", fmt.Errorf("failed to update VirtualMachine running state: %v", err)
 	}
 
 	return encodeProviderID(string(virtualMachine.UID)), nil
 }
 
-func (p PluginSPIImpl) getVM(ctx context.Context, secret *corev1.Secret, machineName, namespace string) (*kubevirtv1.VirtualMachine, error) {
-	c, err := p.client(secret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubevirt client: %v", err)
-	}
-
+func (p PluginSPIImpl) getVM(ctx context.Context, c client.Client, machineName, namespace string) (*kubevirtv1.VirtualMachine, error) {
 	virtualMachine := &kubevirtv1.VirtualMachine{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: machineName}, virtualMachine); err != nil {
 		if kerrors.IsNotFound(err) {
@@ -285,21 +303,15 @@ func (p PluginSPIImpl) getVM(ctx context.Context, secret *corev1.Secret, machine
 				Name: machineName,
 			}
 		}
-		return nil, fmt.Errorf("failed to find kubevirt virtualMachine: %v", err)
+		return nil, fmt.Errorf("failed to get VirtualMachine: %v", err)
 	}
-
 	return virtualMachine, nil
 }
 
-func (p PluginSPIImpl) listVMs(ctx context.Context, secret *corev1.Secret) (map[string]string, error) {
-	c, err := p.client(secret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubevirt client: %v", err)
-	}
-
+func (p PluginSPIImpl) listVMs(ctx context.Context, c client.Client, namespace string) (map[string]string, error) {
 	virtualMachineList := &kubevirtv1.VirtualMachineList{}
-	if err := c.List(ctx, virtualMachineList, &client.ListOptions{}); err != nil {
-		return nil, fmt.Errorf("failed to list kubevirt virtual machines: %v", err)
+	if err := c.List(ctx, virtualMachineList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMachines: %v", err)
 	}
 
 	var providerIDs = make(map[string]string, len(virtualMachineList.Items))
@@ -311,8 +323,8 @@ func (p PluginSPIImpl) listVMs(ctx context.Context, secret *corev1.Secret) (map[
 	return providerIDs, nil
 }
 
-func (p PluginSPIImpl) machineProviderID(ctx context.Context, secret *corev1.Secret, virtualMachineName, namespace string) (string, error) {
-	virtualMachine, err := p.getVM(ctx, secret, virtualMachineName, namespace)
+func (p PluginSPIImpl) machineProviderID(ctx context.Context, c client.Client, machineName, namespace string) (string, error) {
+	virtualMachine, err := p.getVM(ctx, c, machineName, namespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubevirt/core/util_test.go
+++ b/pkg/kubevirt/core/util_test.go
@@ -5,47 +5,46 @@ import (
 	"testing"
 )
 
-var (
-	testCases = []struct {
-		name             string
-		userData         string
-		sshKeys          []string
-		expectedUserData string
-		expectedError    bool
-	}{
-		{
-			name:             "`ssh_authorized_keys` key already exists error",
-			userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu",
-			sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
-			expectedUserData: "",
-			expectedError:    true,
-		},
-		{
-			name:             "add user ssh key to userdata successfully",
-			userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test",
-			sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
-			expectedUserData: "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b",
-			expectedError:    false,
-		},
-	}
-)
-
 func TestAddUserSSHKeysToUserData(t *testing.T) {
+	var (
+		testCases = []struct {
+			name             string
+			userData         string
+			sshKeys          []string
+			expectedUserData string
+			expectedError    bool
+		}{
+			{
+				name:             "`ssh_authorized_keys` key already exists error",
+				userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu",
+				sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
+				expectedUserData: "",
+				expectedError:    true,
+			},
+			{
+				name:             "add user ssh key to userdata successfully",
+				userData:         "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test",
+				sshKeys:          []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b"},
+				expectedUserData: "#cloud-config\nchpasswd:\nexpire: false\npassword: pass\nuser: test\nssh_authorized_keys:\n- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3b",
+				expectedError:    false,
+			},
+		}
+	)
+
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			u, err := addUserSSHKeysToUserData(testCase.userData, testCase.sshKeys)
 			if testCase.expectedError && err == nil {
-				t.Fatal("expected an error but got error: nil")
+				t.Fatal("expected an error but got a nil error")
 			}
 
 			if err != nil && !testCase.expectedError {
-				t.Fatalf("unexpected error was encoutred: %v", err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if strings.TrimSpace(testCase.expectedUserData) != strings.TrimSpace(u) {
-				t.Fatalf("expecting userdata: %v and got: %v", testCase.expectedUserData, u)
+				t.Fatalf("expected userdata: %v and got: %v", testCase.expectedUserData, u)
 			}
-
 		})
 	}
 }

--- a/pkg/kubevirt/machine_server.go
+++ b/pkg/kubevirt/machine_server.go
@@ -49,17 +49,17 @@ import (
 //
 func (p *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMachineRequest) (*driver.CreateMachineResponse, error) {
 	// Log messages to track request
-	klog.V(2).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
-	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
+	klog.V(2).Infof("CreateMachine request has been received for %q", req.Machine.Name)
+	defer klog.V(2).Infof("CreateMachine request has been processed for %q", req.Machine.Name)
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Create machine %q failed on decodeProviderSpecAndSecret", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not decode provider spec and secret")
 	}
 
 	providerID, err := p.SPI.CreateMachine(ctx, req.Machine.Name, providerSpec, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Create machine %q failed", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not create machine %q", req.Machine.Name)
 	}
 
 	response := &driver.CreateMachineResponse{
@@ -83,17 +83,17 @@ func (p *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMac
 //
 func (p *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMachineRequest) (*driver.DeleteMachineResponse, error) {
 	// Log messages to track delete request
-	klog.V(2).Infof("Machine deletion request has been recieved for %q", req.Machine.Name)
-	defer klog.V(2).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
+	klog.V(2).Infof("DeleteMachine request has been received for %q", req.Machine.Name)
+	defer klog.V(2).Infof("DeleteMachine request has been processed for %q", req.Machine.Name)
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Create machine %q failed on decodeProviderSpecAndSecret", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not decode provider spec and secret")
 	}
 
 	providerID, err := p.SPI.DeleteMachine(ctx, req.Machine.Name, req.Machine.Spec.ProviderID, providerSpec, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Create machine %q failed", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not delete machine %q", req.Machine.Name)
 	}
 
 	response := &driver.DeleteMachineResponse{
@@ -120,17 +120,17 @@ func (p *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMac
 // The request should return a NOT_FOUND (5) status errors code if the machine is not existing
 func (p *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMachineStatusRequest) (*driver.GetMachineStatusResponse, error) {
 	// Log messages to track start and end of request
-	klog.V(2).Infof("Get request has been recieved for %q", req.Machine.Name)
-	defer klog.V(2).Infof("Machine get request has been processed successfully for %q", req.Machine.Name)
+	klog.V(2).Infof("GetMachineStatus request has been received for %q", req.Machine.Name)
+	defer klog.V(2).Infof("GetMachineStatus request has been processed for %q", req.Machine.Name)
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Create machine %q failed on decodeProviderSpecAndSecret", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not decode provider spec and secret")
 	}
 
 	providerID, err := p.SPI.GetMachineStatus(ctx, req.Machine.Name, req.Machine.Spec.ProviderID, providerSpec, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "Machine status %q failed", req.Machine.Name)
+		return nil, prepareErrorf(err, "could not get status of machine %q", req.Machine.Name)
 	}
 
 	response := &driver.GetMachineStatusResponse{
@@ -138,7 +138,7 @@ func (p *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMac
 		NodeName:   req.Machine.Name,
 	}
 
-	klog.V(2).Infof("Machine status: found VM %q for Machine: %q", response.ProviderID, req.Machine.Name)
+	klog.V(2).Infof("Found machine with provider ID %q for %q", response.ProviderID, req.Machine.Name)
 
 	return response, nil
 }
@@ -158,20 +158,20 @@ func (p *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMac
 //
 func (p *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachinesRequest) (*driver.ListMachinesResponse, error) {
 	// Log messages to track start and end of request
-	klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
-	defer klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
+	klog.V(2).Infof("ListMachines request has been received for %q", req.MachineClass.Name)
+	defer klog.V(2).Infof("ListMachines request has been processed for %q", req.MachineClass.Name)
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "List machines failed on decodeProviderSpecAndSecret")
+		return nil, prepareErrorf(err, "could not decode provider spec and secret")
 	}
 
 	machineList, err := p.SPI.ListMachines(ctx, providerSpec, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "List machines failed")
+		return nil, prepareErrorf(err, "could not list machines")
 	}
 
-	klog.V(2).Infof("List machines request for kubevirt cluster, found %d machines", len(machineList))
+	klog.V(2).Infof("Found %d machines for %q", len(machineList), req.MachineClass.Name)
 
 	return &driver.ListMachinesResponse{
 		MachineList: machineList,
@@ -188,8 +188,8 @@ func (p *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachin
 //
 func (p *MachinePlugin) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
 	// Log messages to track start and end of request
-	klog.V(2).Infof("GetVolumeIDs request has been recieved for %q", req.PVSpecs)
-	defer klog.V(2).Infof("GetVolumeIDs request has been processed successfully for %q", req.PVSpecs)
+	klog.V(2).Infof("GetVolumeIDs request has been received for %q", req.PVSpecs)
+	defer klog.V(2).Infof("GetVolumeIDs request has been processed for %q", req.PVSpecs)
 
 	return &driver.GetVolumeIDsResponse{}, status.Error(codes.Unimplemented, "")
 }

--- a/pkg/kubevirt/plugin.go
+++ b/pkg/kubevirt/plugin.go
@@ -50,9 +50,9 @@ type MachinePlugin struct {
 
 // NewKubevirtPlugin returns a new Kubevirt cloud provider driver.
 func NewKubevirtPlugin() driver.Driver {
-	plugin, err := core.NewPluginSPIImpl(core.KubevirtClient)
+	plugin, err := core.NewPluginSPIImpl(core.ClientFactoryFunc(core.GetClient))
 	if err != nil {
-		klog.Errorf("failed to create a kubevirt driver")
+		klog.Errorf("failed to create Kubevirt plugin")
 		return nil
 	}
 

--- a/pkg/kubevirt/util/util.go
+++ b/pkg/kubevirt/util/util.go
@@ -34,7 +34,7 @@ func DNSPolicy(policy string) (corev1.DNSPolicy, error) {
 		return corev1.DNSNone, nil
 	}
 
-	return "", fmt.Errorf("unknown dns policy: %s", policy)
+	return "", fmt.Errorf("unknown DNS policy: %s", policy)
 }
 
 // ParseResources receives cpus and memory parameters and parse them as a ResourceList to be used in the virtual machine.

--- a/pkg/kubevirt/validation/validation.go
+++ b/pkg/kubevirt/validation/validation.go
@@ -83,7 +83,7 @@ func validateSecrets(secret *corev1.Secret) []error {
 	var validationErrors []error
 
 	if secret == nil {
-		validationErrors = append(validationErrors, errors.New("secret object that has been passed by the MCM is nil"))
+		validationErrors = append(validationErrors, errors.New("secret object passed by the MCM is nil"))
 	} else {
 		kubeconfig, kubevirtKubeconifgCheck := secret.Data["kubeconfig"]
 		_, userdataCheck := secret.Data["userData"]


### PR DESCRIPTION
**What this PR does / why we need it**:
* Removes the namespace from the provider spec and uses the namespace from the provider secret (`default` if empty). 
* Introduces a helper function for getting the client and the namespace from the provider secret.
* Fixes and improves unit tests.
* Improves log and error messages.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-kubevirt/issues/18

**Special notes for your reviewer**:
Should be tested together with https://github.com/gardener/gardener-extension-provider-kubevirt/pull/19

**Release note**:
```improvement operator
NONE
```
