### PR TITLE
adding vm tags support

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -42,6 +42,9 @@ type KubeVirtProviderSpec struct {
 	// the pod network won't be added, otherwise it will be added as default.
 	// +optional
 	Networks []NetworkSpec `json:"networks,omitempty"`
+	// Tags is an optional map of tags that is added to the VM as labels.
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 // NetworkSpec contains information about a network.

--- a/pkg/kubevirt/core/core.go
+++ b/pkg/kubevirt/core/core.go
@@ -127,13 +127,18 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 		}
 	}
 
+	var vmLabels = map[string]string{}
+	if len(providerSpec.Tags) > 0 {
+		vmLabels = providerSpec.Tags
+	}
+
+	vmLabels["kubevirt.io/vm"] = machineName
+
 	virtualMachine := &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"kubevirt.io/vm": machineName,
-			},
+			Labels:    vmLabels,
 		},
 		Spec: kubevirtv1.VirtualMachineSpec{
 			Running: utilpointer.BoolPtr(true),


### PR DESCRIPTION
**What this PR does / why we need it**:
Passing tags to the kubevirt vm as labels.

**Which issue(s) this PR fixes**:
Fixes #11 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Pass tags to the kubevirt vms
```
