### PR TITLE
Fix machine provider ID to match node ID

### DIFF
--- a/pkg/kubevirt/core/core_test.go
+++ b/pkg/kubevirt/core/core_test.go
@@ -80,7 +80,7 @@ func TestPluginSPIImpl_GetMachineStatus(t *testing.T) {
 			t.Fatalf("failed to get machine status: %v", err)
 		}
 
-		if providerID != "" {
+		if providerID != ProviderName+"://"+machineName {
 			t.Fatal("provider id doesn't match the expected value")
 		}
 	})

--- a/pkg/kubevirt/core/util.go
+++ b/pkg/kubevirt/core/util.go
@@ -53,11 +53,11 @@ func GetClient(secret *corev1.Secret) (client.Client, string, error) {
 	return c, namespace, nil
 }
 
-func encodeProviderID(machineID string) string {
-	if machineID == "" {
+func encodeProviderID(machineName string) string {
+	if machineName == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/%s", ProviderName, machineID)
+	return fmt.Sprintf("%s://%s", ProviderName, machineName)
 }
 
 func buildNetworks(networkSpecs []api.NetworkSpec) ([]kubevirtv1.Interface, []kubevirtv1.Network, string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the machine provider ID to match the node ID assigned by the Kubevirt CCM, `kubevirt://<machine-name>`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-kubevirt/issues/34

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
