### PR TITLE
Add DNS config to networkData

### DIFF
--- a/pkg/kubevirt/core/util.go
+++ b/pkg/kubevirt/core/util.go
@@ -164,6 +164,8 @@ ethernets:
     match:
       name: "e*"
     dhcp4: true
+    nameservers:
+      addresses: [8.8.8.8]
 `
 
 	return interfaces, networks, networkData


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds DNS config to `networkData` as a workaround for https://github.com/kubevirt/kubevirt/issues/4267.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Eventually we should probably enable specifying `networkData` via the `ProviderSpec`. For the moment, hardcoding `nameservers` should be OK, similarly to how we hardcoded `dhcp4` in the past.

**Release note**:
```improvement operator
NONE
```

/area networking
/kind enhancement
/priority normal
/provider kubevirt
