### PR TITLE
Change DNS fields from string to appropriate k8s core v1 structs

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -14,6 +14,10 @@
 
 package api
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 // KubeVirtProviderSpec is the spec to be used while parsing the calls.
 type KubeVirtProviderSpec struct {
 	// SourceURL is the HTTP URL of the source image imported by CDI.
@@ -29,12 +33,12 @@ type KubeVirtProviderSpec struct {
 	// DNSConfig is the DNS configuration of the VM pod.
 	// The parameters specified here will be merged with the generated DNS configuration based on DNSPolicy.
 	// +optional
-	DNSConfig string `json:"dnsConfig,omitempty"`
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 	// DNSPolicy is the DNS policy for the VM pod.
 	// Defaults to "ClusterFirst" and valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
 	// To have DNS options set along with hostNetwork, specify DNS policy as 'ClusterFirstWithHostNet'.
 	// +optional
-	DNSPolicy string `json:"dnsPolicy,omitempty"`
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
 	// SSHKeys is an optional list of SSH public keys added to the VM (may already be included in UserData)
 	// +optional
 	SSHKeys []string `json:"sshKeys,omitempty"`

--- a/pkg/kubevirt/core/core.go
+++ b/pkg/kubevirt/core/core.go
@@ -26,7 +26,6 @@ import (
 	clouderrors "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/errors"
 	"github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/util"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -113,23 +112,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 		pvcRequest                    = corev1.ResourceList{corev1.ResourceStorage: pvcSize}
 		terminationGracePeriodSeconds = int64(30)
 		userdataSecretName            = fmt.Sprintf("userdata-%s-%s", machineName, strconv.Itoa(int(time.Now().Unix())))
-
-		dnsPolicy corev1.DNSPolicy
-		dnsConfig *corev1.PodDNSConfig
 	)
-
-	if providerSpec.DNSPolicy != "" {
-		dnsPolicy, err = util.DNSPolicy(providerSpec.DNSPolicy)
-		if err != nil {
-			return "", fmt.Errorf("invalid DNS policy: %v", err)
-		}
-	}
-
-	if providerSpec.DNSConfig != "" {
-		if err := yaml.Unmarshal([]byte(providerSpec.DNSConfig), dnsConfig); err != nil {
-			return "", fmt.Errorf(`failed to unmarshal "dnsConfig" field: %v`, err)
-		}
-	}
 
 	interfaces, networks, networkData := buildNetworks(providerSpec.Networks)
 
@@ -253,8 +236,8 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 							},
 						},
 					},
-					DNSPolicy: dnsPolicy,
-					DNSConfig: dnsConfig,
+					DNSPolicy: providerSpec.DNSPolicy,
+					DNSConfig: providerSpec.DNSConfig,
 					Networks:  networks,
 					Affinity:  affinity,
 				},

--- a/pkg/kubevirt/util/util.go
+++ b/pkg/kubevirt/util/util.go
@@ -21,22 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// DNSPolicy receives a policy as a string and converts it to a kubevirt DNSPolicy to be used in the virtual machine.
-func DNSPolicy(policy string) (corev1.DNSPolicy, error) {
-	switch policy {
-	case string(corev1.DNSClusterFirstWithHostNet):
-		return corev1.DNSClusterFirstWithHostNet, nil
-	case string(corev1.DNSClusterFirst):
-		return corev1.DNSClusterFirst, nil
-	case string(corev1.DNSDefault):
-		return corev1.DNSDefault, nil
-	case string(corev1.DNSNone):
-		return corev1.DNSNone, nil
-	}
-
-	return "", fmt.Errorf("unknown DNS policy: %s", policy)
-}
-
 // ParseResources receives cpus and memory parameters and parse them as a ResourceList to be used in the virtual machine.
 func ParseResources(cpus, memory string) (*corev1.ResourceList, error) {
 	memoryResource, err := resource.ParseQuantity(memory)


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

**What this PR does / why we need it**:
Changing the field types from string to appropriate k8s core v1 structs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
improvement_operator
```
