### PR TITLE
Fix gRPC error decoding errors

### DIFF
--- a/pkg/kubevirt/machine_server.go
+++ b/pkg/kubevirt/machine_server.go
@@ -54,7 +54,7 @@ func (p *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMac
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "could not decode provider spec and secret")
+		return nil, err
 	}
 
 	providerID, err := p.SPI.CreateMachine(ctx, req.Machine.Name, providerSpec, req.Secret)
@@ -88,7 +88,7 @@ func (p *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMac
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "could not decode provider spec and secret")
+		return nil, err
 	}
 
 	providerID, err := p.SPI.DeleteMachine(ctx, req.Machine.Name, req.Machine.Spec.ProviderID, providerSpec, req.Secret)
@@ -125,7 +125,7 @@ func (p *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMac
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "could not decode provider spec and secret")
+		return nil, err
 	}
 
 	providerID, err := p.SPI.GetMachineStatus(ctx, req.Machine.Name, req.Machine.Spec.ProviderID, providerSpec, req.Secret)
@@ -163,7 +163,7 @@ func (p *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachin
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
-		return nil, prepareErrorf(err, "could not decode provider spec and secret")
+		return nil, err
 	}
 
 	machineList, err := p.SPI.ListMachines(ctx, providerSpec, req.Secret)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes gRPC error decoding errors during shoot cluster deletion.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The following errors were observed in Gardenlet logs:

```yaml
time="2020-10-01T18:43:34+03:00" level=error msg="Worker shoot--dev--i500152-kubevirt/i500152-kubevirt did not get deleted yet, lastError is: Error deleting worker: could not delete worker resouces: Failed while waiting for all machine resources to be deleted: 'machine shoot--dev--i500152-kubevirt-cpu-worker-z-6c94c4bfc7-lm956 failed: Error occurred with decoding gRPC error status while getting VM status, aborting without retry. Set machine status to termination. Now, getting VM Status'" operation=reconcile shoot=garden-dev/i500152-kubevirt
```

They were caused by the actual error being wrapped twice in `status.Error`, which is now fixed. There is also a bug in MCM that causes a `GetMachineStatus` call with a `nil` secret (the machine class is not deleted immediately due to a finalizer, but the secret is deleted immediately), so there are still errors, but at least now the root cause `secret object passed by the MCM is nil` is properly visible:

```yaml
time="2020-10-02T16:48:26+03:00" level=error msg="Worker shoot--dev--i500152-kubevirt/i500152-kubevirt did not get deleted yet, lastError is: Error deleting worker: could not delete worker resouces: Failed while waiting for all machine resources to be deleted: 'machine shoot--dev--i500152-kubevirt-cpu-worker-z-75cd59bf-6pvnw failed: Error occurred with decoding gRPC error status while getting VM status, aborting without retry. gRPC code: secret object passed by the MCM is nil Set machine status to termination. Now, getting VM Status'" operation=reconcile shoot=garden-dev/i500152-kubevirt
```

**Release note**:
```improvement operator
NONE
```
