### PR TITLE
Accept a single zone in provider spec

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -22,15 +22,15 @@ import (
 // KubeVirtProviderSpec is the spec to be used while parsing the calls.
 type KubeVirtProviderSpec struct {
 	// SourceURL is the HTTP URL of the source image imported by CDI.
-	SourceURL string `json:"sourceURL,omitempty"`
+	SourceURL string `json:"sourceURL"`
 	// StorageClassName is the name which CDI uses to in order to create claims.
-	StorageClassName string `json:"storageClassName,omitempty"`
+	StorageClassName string `json:"storageClassName"`
 	// PVCSize is the size of the PersistentVolumeClaim that is created during the image import by CDI.
-	PVCSize string `json:"pvcSize,omitempty"`
+	PVCSize string `json:"pvcSize"`
 	// CPUs is the number of CPUs requested by the VM.
-	CPUs string `json:"cpus,omitempty"`
+	CPUs string `json:"cpus"`
 	// Memory is the amount of memory requested by the VM.
-	Memory string `json:"memory,omitempty"`
+	Memory string `json:"memory"`
 	// DNSConfig is the DNS configuration of the VM pod.
 	// The parameters specified here will be merged with the generated DNS configuration based on DNSPolicy.
 	// +optional
@@ -48,10 +48,10 @@ type KubeVirtProviderSpec struct {
 	// +optional
 	Networks []NetworkSpec `json:"networks,omitempty"`
 	// Region is the name of the region for the VM.
-	Region string
-	// Zones is a list of availability zones for the VM.
+	Region string `json:"region"`
+	// Zone is the name of the zone for the VM.
 	// +optional
-	Zones []string
+	Zone string `json:"zone,omitempty"`
 	// Tags is an optional map of tags that is added to the VM as labels.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
@@ -60,7 +60,8 @@ type KubeVirtProviderSpec struct {
 	// For hugepages take a look at:
 	// k8s - https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/
 	// okd - https://docs.okd.io/3.9/scaling_performance/managing_hugepages.html#huge-pages-prerequisites
-	MemoryFeatures *kubevirtv1.Memory
+	// +optional
+	MemoryFeatures *kubevirtv1.Memory `json:"memoryFeatures,omitempty"`
 }
 
 // NetworkSpec contains information about a network.

--- a/pkg/kubevirt/core/core.go
+++ b/pkg/kubevirt/core/core.go
@@ -121,7 +121,7 @@ func (p PluginSPIImpl) CreateMachine(ctx context.Context, machineName string, pr
 		return "", fmt.Errorf("failed to get server version: %v", err)
 	}
 
-	affinity := buildAffinity(providerSpec.Region, providerSpec.Zones, k8sVersion)
+	affinity := buildAffinity(providerSpec.Region, providerSpec.Zone, k8sVersion)
 
 	userData := string(secret.Data["userData"])
 	if len(providerSpec.SSHKeys) > 0 {

--- a/pkg/kubevirt/core/util.go
+++ b/pkg/kubevirt/core/util.go
@@ -178,7 +178,7 @@ const (
 	defaultZone = "default"
 )
 
-func buildAffinity(region string, zones []string, k8sVersion string) *corev1.Affinity {
+func buildAffinity(region, zone, k8sVersion string) *corev1.Affinity {
 	var affinity *corev1.Affinity
 	if region != "" {
 		// Get region and zone labels
@@ -199,13 +199,13 @@ func buildAffinity(region string, zones []string, k8sVersion string) *corev1.Aff
 			})
 		}
 
-		// If there are zones, add match expression for the zone label
-		if len(zones) > 0 {
-			if len(zones) > 1 || zones[0] != defaultZone {
+		// If there is a zone, add match expression for the zone label
+		if zone != "" {
+			if zone != defaultZone {
 				matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
 					Key:      zoneLabel,
 					Operator: corev1.NodeSelectorOpIn,
-					Values:   zones,
+					Values:   []string{zone},
 				})
 			} else {
 				matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the provider spec to accept a single zone instead of a list of zones, and adapts the handling of zones appropriately. After https://github.com/gardener/gardener-extension-provider-kubevirt/pull/77 is merged, the provider extension will pass a single zone instead of a list.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Should be merged together with https://github.com/gardener/gardener-extension-provider-kubevirt/pull/77.

**Release note**:
```improvement operator
NONE
```
