### PR TITLE
Ensure consistent ordering of provider spec fields

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -22,46 +22,42 @@ import (
 
 // KubeVirtProviderSpec is the spec to be used while parsing the calls.
 type KubeVirtProviderSpec struct {
-	// Resources defines requests and limits resources of VMI
+	// Region is the VM region name.
+	Region string `json:"region"`
+	// Zone is the VM zone name.
+	Zone string `json:"zone"`
+	// Resources specifies the requests and limits for VM resources (CPU and memory).
 	Resources kubevirtv1.ResourceRequirements `json:"resources"`
 	// RootVolume is the specification for the root volume of the VM.
 	RootVolume cdicorev1alpha1.DataVolumeSpec `json:"rootVolume"`
 	// AdditionalVolumes is an optional list of additional volumes attached to the VM.
 	// +optional
 	AdditionalVolumes []AdditionalVolumeSpec `json:"additionalVolumes,omitempty"`
-	// Region is the name of the region for the VM.
-	Region string `json:"region"`
-	// Zone is the name of the zone for the VM.
-	Zone string `json:"zone"`
-	// DNSConfig is the DNS configuration of the VM pod.
-	// The parameters specified here will be merged with the generated DNS configuration based on DNSPolicy.
-	// +optional
-	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
-	// DNSPolicy is the DNS policy for the VM pod.
-	// Defaults to "ClusterFirst" and valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
-	// To have DNS options set along with hostNetwork, specify DNS policy as 'ClusterFirstWithHostNet'.
-	// +optional
-	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
-	// SSHKeys is an optional list of SSH public keys added to the VM (may already be included in UserData)
+	// SSHKeys is an optional list of SSH public keys added to the VM.
 	// +optional
 	SSHKeys []string `json:"sshKeys,omitempty"`
 	// Networks is an optional list of networks for the VM. If any of the networks is specified as "default"
 	// the pod network won't be added, otherwise it will be added as default.
 	// +optional
 	Networks []NetworkSpec `json:"networks,omitempty"`
-	// Tags is an optional map of tags that is added to the VM as labels.
-	// +optional
-	Tags map[string]string `json:"tags,omitempty"`
-	// CPU allows specifying the CPU topology of KubeVirt VM.
+	// CPU allows specifying the CPU topology of the VM.
 	// +optional
 	CPU *kubevirtv1.CPU `json:"cpu,omitempty"`
-	// Memory allows specifying the VirtualMachineInstance memory features like huge pages and guest memory settings.
-	// Each feature might require appropriate FeatureGate enabled.
-	// For hugepages take a look at:
-	// k8s - https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/
-	// okd - https://docs.okd.io/3.9/scaling_performance/managing_hugepages.html#huge-pages-prerequisites
+	// Memory allows specifying the VM memory features such as hugepages and guest memory settings.
+	// Each feature might require enabling the appropriate feature gate.
 	// +optional
 	Memory *kubevirtv1.Memory `json:"memory,omitempty"`
+	// DNSPolicy is the DNS policy of the VM pod.
+	// Defaults to "ClusterFirst" and valid values are "ClusterFirstWithHostNet", "ClusterFirst", "Default" or "None".
+	// +optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+	// DNSConfig is the DNS configuration of the VM pod.
+	// The parameters specified here will be merged with the DNS configuration generated based on DNSPolicy.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	// Tags is an optional map of tags that are added to the VM as labels.
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 // AdditionalVolumeSpec represents an additional volume attached to a VM.
@@ -79,7 +75,6 @@ type AdditionalVolumeSpec struct {
 // Only one of its members may be specified.
 type VolumeSource struct {
 	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
-	// Directly attached to the vmi via qemu.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	// +optional
 	PersistentVolumeClaim *corev1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`

--- a/pkg/kubevirt/core/core_test.go
+++ b/pkg/kubevirt/core/core_test.go
@@ -34,24 +34,8 @@ import (
 
 var (
 	providerSpec = &api.KubeVirtProviderSpec{
-		RootVolume: cdicorev1alpha1.DataVolumeSpec{
-			PVC: &corev1.PersistentVolumeClaimSpec{
-				StorageClassName: pointer.StringPtr("test-sc"),
-				AccessModes: []corev1.PersistentVolumeAccessMode{
-					"ReadWriteOnce",
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
-					},
-				},
-			},
-			Source: cdicorev1alpha1.DataVolumeSource{
-				HTTP: &cdicorev1alpha1.DataVolumeSourceHTTP{
-					URL: "http://test-image.com",
-				},
-			},
-		},
+		Region: "default",
+		Zone:   "default",
 		Resources: kubevirtv1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -60,6 +44,24 @@ var (
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		RootVolume: cdicorev1alpha1.DataVolumeSpec{
+			PVC: &corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					"ReadWriteOnce",
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+				StorageClassName: pointer.StringPtr("test-sc"),
+			},
+			Source: cdicorev1alpha1.DataVolumeSource{
+				HTTP: &cdicorev1alpha1.DataVolumeSourceHTTP{
+					URL: "http://test-image.com",
+				},
 			},
 		},
 	}

--- a/pkg/kubevirt/validation/validation.go
+++ b/pkg/kubevirt/validation/validation.go
@@ -31,6 +31,14 @@ import (
 func ValidateKubevirtProviderSpec(spec *api.KubeVirtProviderSpec) field.ErrorList {
 	errs := field.ErrorList{}
 
+	if spec.Region == "" {
+		errs = append(errs, field.Required(field.NewPath("region"), "cannot be empty"))
+	}
+
+	if spec.Zone == "" {
+		errs = append(errs, field.Required(field.NewPath("zone"), "cannot be empty"))
+	}
+
 	requestsPath := field.NewPath("resources").Child("requests")
 	if spec.Resources.Requests.Memory().IsZero() {
 		errs = append(errs, field.Required(requestsPath.Child("memory"), "cannot be zero"))
@@ -52,14 +60,6 @@ func ValidateKubevirtProviderSpec(spec *api.KubeVirtProviderSpec) field.ErrorLis
 		default:
 			errs = append(errs, field.Invalid(volumePath, volume, "invalid volume, either dataVolume or volumeSource must be specified"))
 		}
-	}
-
-	if spec.Region == "" {
-		errs = append(errs, field.Required(field.NewPath("region"), "cannot be empty"))
-	}
-
-	if spec.Zone == "" {
-		errs = append(errs, field.Required(field.NewPath("zone"), "cannot be empty"))
 	}
 
 	if spec.DNSPolicy != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures consistent ordering and documentation of provider spec fields, in line with https://github.com/gardener/gardener-extension-provider-kubevirt/pull/82.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
