### PR TITLE
Improve error wrapping, error messages, and comments

### DIFF
--- a/pkg/kubevirt/apis/provider_spec.go
+++ b/pkg/kubevirt/apis/provider_spec.go
@@ -20,7 +20,8 @@ import (
 	cdicorev1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 )
 
-// KubeVirtProviderSpec is the spec to be used while parsing the calls.
+// KubeVirtProviderSpec is the kubevirt provider specification.
+// It contains parameters to be used when creating kubevirt VMs.
 type KubeVirtProviderSpec struct {
 	// Region is the VM region name.
 	Region string `json:"region"`

--- a/pkg/kubevirt/core/core_test.go
+++ b/pkg/kubevirt/core/core_test.go
@@ -81,12 +81,9 @@ func TestPluginSPIImpl_CreateMachine(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 	t.Run("CreateMachine", func(t *testing.T) {
 		mf := newMockFactory(fakeClient, namespace, serverVersion)
-		plugin, err := NewPluginSPIImpl(mf, mf)
-		if err != nil {
-			t.Fatalf("failed to create plugin: %v", err)
-		}
+		plugin := NewPluginSPIImpl(mf, mf)
 
-		_, err = plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
+		_, err := plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
 		if err != nil {
 			t.Fatalf("failed to create machine: %v", err)
 		}
@@ -106,12 +103,9 @@ func TestPluginSPIImpl_GetMachineStatus(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 	t.Run("GetMachineStatus", func(t *testing.T) {
 		mf := newMockFactory(fakeClient, namespace, serverVersion)
-		plugin, err := NewPluginSPIImpl(mf, mf)
-		if err != nil {
-			t.Fatalf("failed to create plugin: %v", err)
-		}
+		plugin := NewPluginSPIImpl(mf, mf)
 
-		_, err = plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
+		_, err := plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
 		if err != nil {
 			t.Fatalf("failed to create machine: %v", err)
 		}
@@ -131,12 +125,9 @@ func TestPluginSPIImpl_ListMachines(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 	t.Run("ListMachines", func(t *testing.T) {
 		mf := newMockFactory(fakeClient, namespace, serverVersion)
-		plugin, err := NewPluginSPIImpl(mf, mf)
-		if err != nil {
-			t.Fatalf("failed to create plugin: %v", err)
-		}
+		plugin := NewPluginSPIImpl(mf, mf)
 
-		_, err = plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
+		_, err := plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
 		if err != nil {
 			t.Fatalf("failed to create machine: %v", err)
 		}
@@ -156,10 +147,7 @@ func TestPluginSPIImpl_ShutDownMachine(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 	t.Run("ShutDownMachine", func(t *testing.T) {
 		mf := newMockFactory(fakeClient, namespace, serverVersion)
-		plugin, err := NewPluginSPIImpl(mf, mf)
-		if err != nil {
-			t.Fatalf("failed to create plugin: %v", err)
-		}
+		plugin := NewPluginSPIImpl(mf, mf)
 
 		providerID, err := plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
 		if err != nil {
@@ -186,10 +174,7 @@ func TestPluginSPIImpl_DeleteMachine(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 	t.Run("DeleteMachine", func(t *testing.T) {
 		mf := newMockFactory(fakeClient, namespace, serverVersion)
-		plugin, err := NewPluginSPIImpl(mf, mf)
-		if err != nil {
-			t.Fatalf("failed to create plugin: %v", err)
-		}
+		plugin := NewPluginSPIImpl(mf, mf)
 
 		providerID, err := plugin.CreateMachine(context.Background(), machineName, providerSpec, &corev1.Secret{})
 		if err != nil {

--- a/pkg/kubevirt/core/errors.go
+++ b/pkg/kubevirt/core/errors.go
@@ -12,26 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errors
+package core
 
 import (
 	"fmt"
 )
 
-// MachineNotFoundError is used to indicate not found error in PluginSPI
+// MachineNotFoundError represents a "machine not found" error.
 type MachineNotFoundError struct {
 	// Name is the machine name
 	Name string
-	// MachineID is the machine uuid
-	MachineID string
 }
 
-// Error returns the MachineNotFoundError message with machine name and uuid.
 func (e *MachineNotFoundError) Error() string {
-	return fmt.Sprintf("machine name=%s, uuid=%s not found", e.Name, e.MachineID)
+	return fmt.Sprintf("machine %q not found", e.Name)
 }
 
-// IsMachineNotFoundError identifies MachineNotFoundError and returns true if it is and false if not.
+// IsMachineNotFoundError returns true if the given error is a MachineNotFoundError, false otherwise.
 func IsMachineNotFoundError(err error) bool {
 	switch err.(type) {
 	case *MachineNotFoundError:

--- a/pkg/kubevirt/core/util.go
+++ b/pkg/kubevirt/core/util.go
@@ -15,13 +15,13 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	api "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/apis"
 
 	"github.com/Masterminds/semver"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -40,15 +40,15 @@ func GetClient(secret *corev1.Secret) (client.Client, string, error) {
 	}
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
-		return nil, "", fmt.Errorf("could not get REST config from client config: %v", err)
+		return nil, "", errors.Wrap(err, "could not get REST config from client config")
 	}
 	c, err := client.New(config, client.Options{})
 	if err != nil {
-		return nil, "", fmt.Errorf("could not create client from REST config: %v", err)
+		return nil, "", errors.Wrap(err, "could not create client from REST config")
 	}
 	namespace, _, err := clientConfig.Namespace()
 	if err != nil {
-		return nil, "", fmt.Errorf("could not get namespace from client config: %v", err)
+		return nil, "", errors.Wrap(err, "could not get namespace from client config")
 	}
 	return c, namespace, nil
 }
@@ -61,15 +61,15 @@ func GetServerVersion(secret *corev1.Secret) (string, error) {
 	}
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
-		return "", fmt.Errorf("could not get REST config from client config: %v", err)
+		return "", errors.Wrap(err, "could not get REST config from client config")
 	}
 	cs, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return "", fmt.Errorf("could not create clientset from REST config: %v", err)
+		return "", errors.Wrap(err, "could not create clientset from REST config")
 	}
 	versionInfo, err := cs.ServerVersion()
 	if err != nil {
-		return "", fmt.Errorf("could not get server version: %v", err)
+		return "", errors.Wrap(err, "could not get server version")
 	}
 	return versionInfo.GitVersion, nil
 }
@@ -81,7 +81,7 @@ func getClientConfig(secret *corev1.Secret) (clientcmd.ClientConfig, error) {
 	}
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not create client config from kubeconfig: %v", err)
+		return nil, errors.Wrap(err, "could not create client config from kubeconfig")
 	}
 	return clientConfig, nil
 }

--- a/pkg/kubevirt/machine_server_util.go
+++ b/pkg/kubevirt/machine_server_util.go
@@ -2,10 +2,9 @@ package kubevirt
 
 import (
 	"encoding/json"
-	"fmt"
 
 	api "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/apis"
-	clouderrors "github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/errors"
+	"github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/core"
 	"github.com/gardener/machine-controller-manager-provider-kubevirt/pkg/kubevirt/validation"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -26,7 +25,7 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	}
 
 	if errs := validation.ValidateKubevirtProviderSpec(spec); len(errs) > 0 {
-		err := fmt.Errorf("could not validate provider spec: %v", errs)
+		err := errors.Errorf("could not validate provider spec: %v", errs)
 		klog.V(2).Infof(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -38,7 +37,7 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	}
 
 	if errs := validation.ValidateKubevirtProviderSecret(secret); len(errs) > 0 {
-		err := fmt.Errorf("could not validate provider secret: %v", errs)
+		err := errors.Errorf("could not validate provider secret: %v", errs)
 		klog.V(2).Infof(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -46,14 +45,14 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	return spec, nil
 }
 
-// prepareErrorf prepares, formats, and wraps the given error in a status.Error.
-func prepareErrorf(err error, format string, args ...interface{}) error {
+// wrapf wraps the given error in a status.Error.
+func wrapf(err error, format string, args ...interface{}) error {
 	var (
 		code    codes.Code
 		wrapped error
 	)
 	switch err.(type) {
-	case *clouderrors.MachineNotFoundError:
+	case *core.MachineNotFoundError:
 		code = codes.NotFound
 		wrapped = err
 	default:

--- a/pkg/kubevirt/validation/validation.go
+++ b/pkg/kubevirt/validation/validation.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package validation is used to validate cloud specific KubeVirtProviderSpec
 package validation
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures consistent error wrapping, error messages, and comments:
* All errors from other packages are wrapped with errors.Wrap or errors.Wrapf.
* All new errors are reported with errors.New and errors.Errorf.
* Using fmt.Errorf is avoided.
* Error messages are reworded to ensure that similar / identical errors are reported with similar / identical messages.
* Formatting and wording of comments is improved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
